### PR TITLE
Ex6: use valid format string marker in utils.plot

### DIFF
--- a/Exercise6/utils.py
+++ b/Exercise6/utils.py
@@ -33,7 +33,7 @@ def plotData(X, y, grid=False):
     neg = y == 0
 
     # Plot Examples
-    pyplot.plot(X[pos, 0], X[pos, 1], 'X', mew=1, ms=10, mec='k')
+    pyplot.plot(X[pos, 0], X[pos, 1], 'x', mew=1, ms=10, mec='k')
     pyplot.plot(X[neg, 0], X[neg, 1], 'o', mew=1, mfc='y', ms=10, mec='k')
     pyplot.grid(grid)
 


### PR DESCRIPTION
`utils.plotData` was failing in Exercise 6.