### PR TITLE
Fix 'Toy Story' movie average calculation bug in Ex8

### DIFF
--- a/Exercise8/exercise8.ipynb
+++ b/Exercise8/exercise8.ipynb
@@ -469,7 +469,7 @@
     "\n",
     "# From the matrix, we can compute statistics like average rating.\n",
     "print('Average rating for movie 1 (Toy Story): %f / 5' %\n",
-    "      np.mean(Y[0, R[0, :]]))\n",
+    "      np.mean(Y[0, R[0, :] == 1]))\n",
     "\n",
     "# We can \"visualize\" the ratings matrix by plotting it with imshow\n",
     "pyplot.figure(figsize=(8, 8))\n",


### PR DESCRIPTION
The indicator matrix should be used for filtering elements instead of selecting elements.