### PR TITLE
Add missing formula to instructions for Backpropagation

### DIFF
--- a/Exercise4/exercise4.ipynb
+++ b/Exercise4/exercise4.ipynb
@@ -664,6 +664,7 @@
     "Note that the symbol $*$ performs element wise multiplication in `numpy`.\n",
     "\n",
     "1. Accumulate the gradient from this example using the following formula. Note that you should skip or remove $\\delta_0^{(2)}$. In `numpy`, removing $\\delta_0^{(2)}$ corresponds to `delta_2 = delta_2[1:]`.\n",
+    "$$ \\Delta^{(l)} = \\Delta^{(l)} + \\delta^{(l+1)}(a^{(l)})^T $$\n",
     "\n",
     "1. Obtain the (unregularized) gradient for the neural network cost function by dividing the accumulated gradients by $\\frac{1}{m}$:\n",
     "$$ \\frac{\\partial}{\\partial \\Theta_{ij}^{(l)}} J(\\Theta) = D_{ij}^{(l)} = \\frac{1}{m} \\Delta_{ij}^{(l)}$$\n",


### PR DESCRIPTION
The formula for point 4 was missing. I copied it from the official instructions.