### PR TITLE
Fixed exercise4.ipynb

### DIFF
--- a/Exercise4/exercise4.ipynb
+++ b/Exercise4/exercise4.ipynb
@@ -664,6 +664,7 @@
     "Note that the symbol $*$ performs element wise multiplication in `numpy`.\n",
     "\n",
     "1. Accumulate the gradient from this example using the following formula. Note that you should skip or remove $\\delta_0^{(2)}$. In `numpy`, removing $\\delta_0^{(2)}$ corresponds to `delta_2 = delta_2[1:]`.\n",
+    "$$ \\Delta^{(l)} = \\Delta^{(l)} + \\delta^{(l+1)} (a^{(l)})^{(T)} $$\n",
     "\n",
     "1. Obtain the (unregularized) gradient for the neural network cost function by dividing the accumulated gradients by $\\frac{1}{m}$:\n",
     "$$ \\frac{\\partial}{\\partial \\Theta_{ij}^{(l)}} J(\\Theta) = D_{ij}^{(l)} = \\frac{1}{m} \\Delta_{ij}^{(l)}$$\n",
@@ -672,7 +673,10 @@
     "**Python/Numpy tip**: You should implement the backpropagation algorithm only after you have successfully completed the feedforward and cost functions. While implementing the backpropagation alogrithm, it is often useful to use the `shape` function to print out the shapes of the variables you are working with if you run into dimension mismatch errors.\n",
     "</div>\n",
     "\n",
-    "[Click here to go back and update the function `nnCostFunction` with the backpropagation algorithm](#nnCostFunction)."
+    "[Click here to go back and update the function `nnCostFunction` with the backpropagation algorithm](#nnCostFunction).\n",
+    "\n",
+    "\n",
+    "**Note:** If the iterative solution provided above is proving to be difficult to implement, try implementing the vectorized approach which is easier to implement in the opinion of the moderators of this course. You can find the tutorial for the vectorized approach [here](https://www.coursera.org/learn/machine-learning/discussions/all/threads/a8Kce_WxEeS16yIACyoj1Q)."
    ]
   },
   {


### PR DESCRIPTION
Added the missing mathematical equation in Point #4 of 2.4 backpropagation. Also added an implementation note linking to the discussions of the course so it could help fellow students to implement vectorized implementation of backpropagation.