### PR TITLE
Update exercise6.ipynb: fixed TypeError in print statement

### DIFF
--- a/Exercise6/exercise6.ipynb
+++ b/Exercise6/exercise6.ipynb
@@ -828,7 +828,7 @@
     "\n",
     "# Print Stats\n",
     "print('\\nLength of feature vector: %d' % len(features))\n",
-    "print('Number of non-zero entries: %d' % sum(features > 0))"
+    "print('Number of non-zero entries: %d' % sum(features))"
    ]
   },
   {


### PR DESCRIPTION
Fixes a TypeError generated by a print statement. The sum over the 0-1 vector should suffice to count the number of non-zero entries.

Error fixed:
`TypeError: '>' not supported between instances of 'list' and 'int'`