### PR TITLE
Updated the e-mail preprocessing pipeline

### DIFF
--- a/Exercise6/exercise6.ipynb
+++ b/Exercise6/exercise6.ipynb
@@ -638,7 +638,7 @@
     "    email_contents = re.split('[ @$/#.-:&*+=\\[\\]?!(){},''\">_<;%\\n\\r]', email_contents)\n",
     "\n",
     "    # remove any empty word string\n",
-    "    email_contents = [word for word in email_contents if len(word) > 0]\n",
+    "    email_contents = [word for word in email_contents.split() if len(word) > 0]\n",
     "    \n",
     "    # Stem the email contents word by word\n",
     "    stemmer = utils.PorterStemmer()\n",


### PR DESCRIPTION
There was an error in the line [word for word  in email_content if len(word)>0], since word in email_content would give characters, not words! (Strings are arrays of characters), to get words, we wust use word in email_content.split()